### PR TITLE
Specificato il significato di modulo Directory

### DIFF
--- a/administrator-manual/it/access.rst
+++ b/administrator-manual/it/access.rst
@@ -25,5 +25,8 @@ Compilare i campi come segue:
 * Nome utente: **root**
 * Password: **password_di_root** (inserita in fase di installazione)
 
-Se è installato il modulo Directory, è possibile abilitare l'utente admin ed utilizzarlo
-per accedere all'interfaccia web con gli stessi privilegi dell'utente root. Vedi :ref:`admin_user-section`.
+Se è installato il pacchetto nethserver-directory, utilizzato dai moduli che abilitano la 
+gestione utenti come File server o Mail, viene attivata nella Dashboard l'interfaccia di 
+gestione :ref:`users-and-groups` dalla quale è possibile abilitare l'utente admin ed utilizzarlo 
+per accedere all'interfaccia web con gli stessi privilegi dell'utente root. 
+Vedi :ref:`admin_user-section`.


### PR DESCRIPTION
Seguendo l'indicazione "modulo Directory" non sono riuscito ad individuare nella gestione pacchetti il modulo con questa nome. 
Ho scoperto che si faceva riferimento al pacchetto nethserver-directory che non può essere installato in autonomia ma è una dipendenza di altri pacchetti che prevedono una gestione utenti.

Può essere differenziare la definizione di pacchetto ( rmp ) da modulo (installabile da gestione pacchetti della dashboard).

Contributo nato da qui
https://groups.google.com/forum/#!topic/nethserver-it/PAVCc4imn48

:-)
