### PR TITLE
"DC factory reset" fix

### DIFF
--- a/developer-manual/en/nethserver-dc.rst
+++ b/developer-manual/en/nethserver-dc.rst
@@ -78,7 +78,7 @@ new provisioning run. ::
     config setprop sssd Provider none status disabled
     > /etc/sssd/sssd.conf
     signal-event nethserver-dnsmasq-save
-
+    config setprop nsdc status disabled
 
 Changing the IP address of DC
 -----------------------------


### PR DESCRIPTION
DC factory resetresult in Start DC  unclickable:

config show nsdc

gives:
nsdc=service
 IpAddress=1.2.3.4
 bridge=br0
 status=enabled

then:
config setprop nsdc status disabled

will set nsdc status to disabled and new start is possible.
I hope this will help others. Cheers