### PR TITLE
Specify the gateway mandatory configuration to use IPSEC

### DIFF
--- a/administrator-manual/en/vpn.rst
+++ b/administrator-manual/en/vpn.rst
@@ -143,6 +143,10 @@ IPsec
 :index:`IPsec` (IP Security) protocol is the 'de facto' standard in VPN tunnels, it's tipically used to create net to net tunnels and it's supported from all manufacturers.
 You can use this protocol to create VPN tunnels between a |product| and a device from another manufacturer as well as VPN tunnels between 2 |product|.
 
+.. note::
+
+ IPSec is not designed to connect single hosts but for net2net configuration, this implies two gateways on both ends (at least one red and one green interfaces).
+
 
 Tunnel (net2net)
 ----------------

--- a/administrator-manual/en/vpn.rst
+++ b/administrator-manual/en/vpn.rst
@@ -145,7 +145,7 @@ You can use this protocol to create VPN tunnels between a |product| and a device
 
 .. note::
 
- IPSec is not designed to connect single hosts but for net2net configuration, this implies two gateways on both ends (at least one red and one green interfaces).
+ IPSec is not designed to connect single hosts but for net2net configuration, this implies two gateways on both ends (at least one red and one green interface).
 
 
 Tunnel (net2net)


### PR DESCRIPTION
You have an error in the template expansion of IPSEC tunnel if one green NIC is not found, this is not implicit and must be written in documentation that you must have red and green interface to use IPSEC tunnel

https://community.nethserver.org/t/blank-dropdown-in-ipsec-tunnel/9894/4