### PR TITLE
Update hotsync.rst

### DIFF
--- a/administrator-manual/en/hotsync.rst
+++ b/administrator-manual/en/hotsync.rst
@@ -141,7 +141,11 @@ The following procedure puts the SLAVE in production when the master has crashed
 
     [root@slave]# /sbin/e-smith/signal-event post-restore-data
 
-7. if an USB backup is configured on MASTER, connect the backup HD to SLAVE
+7. update the system to the latest packages version ::
+
+    [root@slave]# yum clean all && yum -y update
+
+8. if an USB backup is configured on MASTER, connect the backup HD to SLAVE
 
 Supported packages
 ==================


### PR DESCRIPTION
After `post-restore-data` event you should update the former slave server to the latest version of the packages.
Without this step some services could not work as expected (i.e. `shorewall` fails to start and generate an error related an invalid parameter in `/usr/share/shorewall/action.Broadcast` path)