### PR TITLE
typo (SMBUser/SMBLogin)

### DIFF
--- a/administrator-manual/en/backup.rst
+++ b/administrator-manual/en/backup.rst
@@ -428,7 +428,7 @@ Restic backup every day at 3:00 to Amazon S3, no retention limit: ::
 Duplicity backup every day at 22:00 to CIFS, 10 days retention: ::
 
   db backups set mybackup1 duplicity VFSType cifs BackupTime '0 22 * * *' CleanupOlderThan 10D Notify error NotifyFrom '' NotifyTo root@localhost status enabled \
-  SMBHost nas.localnethserver.org SMBUser myuser SMBPassword mypassword SMBShare mybackup
+  SMBHost nas.localnethserver.org SMBLogin myuser SMBPassword mypassword SMBShare mybackup
   signal-event nethserver-backup-data-save mybackup1
 
 


### PR DESCRIPTION
Corrected prop name, otherwise getting error:
>Use of uninitialized value $login in concatenation (.) or string at /etc/e-smith/events/actions/mount-cifs line 67.

Related to https://github.com/NethServer/docs/pull/347