### PR TITLE
ActiveSync SOGo takes precedence

### DIFF
--- a/administrator-manual/en/sogo.rst
+++ b/administrator-manual/en/sogo.rst
@@ -139,21 +139,21 @@ Set by default to 2048KB: ::
 ActiveSync
 ==========
 
-According to this :ref:`webtop-vs-sogo`, WebTop and SOGo can be installed on the same machine.
+According to this :ref:`webtop-vs-sogo`, WebTop and SOGo can be installed on the same machine, although it is discouraged to keep such setup on the long run.
 
-ActiveSync is enabled by default on SOGo and WebTop, but if both packages are installed, WebTop will take precedence.
+ActiveSync is enabled by default on SOGo and WebTop. At installation of SOGo, Webtop-ActiveSync is disabled and SOGo will take precedence.
 
-To disable ActiveSync on SOGo: ::
+SOGo-ActiveSync can be disabled in the server-manager at the SOGo-panel or with: ::
 
   config setprop sogod ActiveSync disabled
   signal-event nethserver-sogo-update
 
-To disable ActiveSync on WebTop: ::
+To enable ActiveSync on WebTop: ::
 
-  config setprop webtop ActiveSync disabled
+  config setprop webtop ActiveSync enabled
   signal-event nethserver-webtop5-update
 
-To enabale ActiveSync on SOGo again: ::
+To enable ActiveSync on SOGo again: ::
 
   config setprop sogod ActiveSync enabled
   signal-event nethserver-sogo-update

--- a/administrator-manual/en/webtop5.rst
+++ b/administrator-manual/en/webtop5.rst
@@ -994,10 +994,10 @@ If you need to delete someone because it is wrong, move with the arrow keys unti
   WebTop vs SOGo
   ==============
 
-  WebTop and SOGo can be installed on the same machine.
+  WebTop and SOGo can be installed on the same machine, although it is discouraged to keep such setup on the long run.
 
   ActiveSync is enabled by default on SOGo and WebTop, but if both packages are
-  installed, WebTop will take precedence.
+  installed, SOGo will take precedence.
 
   To disable ActiveSync on SOGo: ::
 


### PR DESCRIPTION
NethServer/dev#5575

- With the introduction of the SOGo-panel precedence changed.
- discourage to keep Webtop and SOGo installed on the long run.