### PR TITLE
Update backup.rst (disaster-recovery-section)

### DIFF
--- a/administrator-manual/en/backup.rst
+++ b/administrator-manual/en/backup.rst
@@ -697,14 +697,13 @@ Other restored configurations:
 
 Steps to be executed:
 
-1. Install the new machine. If possible, enable a network connection at
-   boot (refer to :ref:`installation-manual` section) to automatically re-install
-   the required modules
+1. Install the new machine, then access the Server Manager and start to follow the :ref:`first-configuration-wizard-section` procedure.
 
-2. Access the Server Manager and follow the :ref:`first-configuration-wizard-section` procedure
+2. At step :guilabel:`Restore configuration`, if you need to change the network roles assignment, don't check the option :guilabel:`Restore configuration`, otherwise the previous network roles will be restored.
+   In this case, once the first configuration wizard will be finished, you'll be able to change the network roles from page :ref:`network`, then you will upload the backup from page :guilabel:`Backup (configuration)`.
 
-3. At step :guilabel:`Restore configuration`, upload the configuration archive.
-   The option :guilabel:`Download modules automatically` should be enabled.
+3. Instead, if you don't need to change the network roles assigment, at step :guilabel:`Restore configuration`, you can upload the configuration archive.
+   The option :guilabel:`Download modules automatically` should be enabled (if possible, enable a network configuration).
 
 4. If a warning message requires it, reconfigure the network roles assignment.
    See :ref:`restore-roles-section` below.

--- a/administrator-manual/en/backup.rst
+++ b/administrator-manual/en/backup.rst
@@ -697,13 +697,12 @@ Other restored configurations:
 
 Steps to be executed:
 
-1. Install the new machine, then access the Server Manager and start to follow the :ref:`first-configuration-wizard-section` procedure.
+1. Install the new machine.
 
-2. At step :guilabel:`Restore configuration`, if you need to change the network roles assignment, don't check the option :guilabel:`Restore configuration`, otherwise the previous network roles will be restored.
-   In this case, once the first configuration wizard will be finished, you'll be able to change the network roles from page :ref:`network`, then you will upload the backup from page :guilabel:`Backup (configuration)`.
+2. Once the new machine is installed, you'll need to enable an Internet connection, so that the restore procedure can donwload the request modules.
+   To do this, access the Server Manager (980 port), do NOT complete the first configuration wizard, and go immediatly to the page :ref:`network`.
 
-3. Instead, if you don't need to change the network roles assigment, at step :guilabel:`Restore configuration`, you can upload the configuration archive.
-   The option :guilabel:`Download modules automatically` should be enabled (if possible, enable a network configuration).
+3. Once the new machine can access to Internet, go to the page :guilabel:`Backup (configuration)` and upload your configuration backup (you can download it from My Nethesis).
 
 4. If a warning message requires it, reconfigure the network roles assignment.
    See :ref:`restore-roles-section` below.

--- a/administrator-manual/en/backup.rst
+++ b/administrator-manual/en/backup.rst
@@ -695,21 +695,24 @@ Other restored configurations:
 
 .. note:: The root/admin password is not restored.
 
+For the correct execution of the restore configuration, it's necessary that the server can access Internet (having an IP and gateway correctly configured).
+In this way, the procedure can download AUTOMATICALLY all modules that were previously installed.
 Steps to be executed:
 
 1. Install the new machine.
 
-2. Once the new machine is installed, you'll need to enable an Internet connection, so that the restore procedure can donwload the request modules.
-   To do this, access the Server Manager (980 port), do NOT complete the first configuration wizard, and go immediatly to the page :ref:`network`.
+2. Access the Server Manager (980 port), do NOT complete the first configuration wizard, and go immediatly to the Dashboard page (to leave the wizard, delete all the parts of the URL after the ":980").
 
-3. Once the new machine can access to Internet, go to the page :guilabel:`Backup (configuration)` and upload your configuration backup (you can download it from My Nethesis).
+3. Once arrived on the Dashboard page, go to the page :ref:`network` and configure the network so that the server can access to Internet.
 
-4. If a warning message requires it, reconfigure the network roles assignment.
+4. Next, go to the page :guilabel:`Backup (configuration)` and upload your configuration backup (you can download it from My Nethesis). The configuration will be restored.
+
+5. At the end, if a warning message requires it, reconfigure the network roles assignment.
    See :ref:`restore-roles-section` below.
 
-5. Verify the system is functional
+6. Verify the system is functional
 
-6. Restore data backup executing on the console ::
+7. Restore data backup executing on the console ::
 
     restore-data
 


### PR DESCRIPTION
The idea is that, in a disaster recovery, you don't need to complete the wizard.

So, after installing the machine, you can skip the wizard, configure the network to access Internet, and then restore the configuration.