### PR TITLE
Rewording Network service definition

### DIFF
--- a/administrator-manual/en/base_system.rst
+++ b/administrator-manual/en/base_system.rst
@@ -154,7 +154,8 @@ Private network   Subnet mask   IP addresses interval
 Network services
 ================
 
-A :index:`network service` is a service running on the firewall itself.
+A remote system can connect to a :index:`network service`, which is a software
+running on |product| itself.
 
 Each service has a list of "open" ports on which it answers to connections.
 Connections can be accepted from selected zones. Finer grained control of 

--- a/administrator-manual/en/base_system2.rst
+++ b/administrator-manual/en/base_system2.rst
@@ -80,7 +80,8 @@ this page allows to:
 Services
 --------
 
-A :index:`service` is a software running on the firewall itself.
+A remote system can connect to a :index:`network service`, which is a software
+running on |product| itself.
 
 Each service can have a list of "open" ports accepting local or remote connections.
 To control which zones or hosts can access a network service, see :ref:`firewall-section`.


### PR DESCRIPTION
Avoid the word "firewall", it sounds out of context here.