### PR TITLE
Move hotsync only to community

### DIFF
--- a/administrator-manual/en/hotsync.rst
+++ b/administrator-manual/en/hotsync.rst
@@ -4,6 +4,10 @@
 HotSync
 =======
 
+.. note::
+
+  This package is not supported in |product| Enterprise
+
 .. warning::
 
    HotSync should be considered a `beta release <https://en.wikipedia.org/wiki/Software_release_life_cycle#Beta>`_.

--- a/administrator-manual/en/index.rst
+++ b/administrator-manual/en/index.rst
@@ -123,6 +123,7 @@ Administrator Manual
        collabora
        sogo
        phpVirtualBox
+       hotsync
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Hotsync is going to be moved to NethForge and supported by community.

NethServer/dev#5996