### PR TITLE
Samba AD restart after skip network

### DIFF
--- a/administrator-manual/en/disaster_recovery.rst
+++ b/administrator-manual/en/disaster_recovery.rst
@@ -192,17 +192,21 @@ See also :ref:`dhcp-section` for more general information.
 Samba Active Directory
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Samba Active Directory requires a network bridge in the green zone for the local running container.
-If the bridge already exists, the container will continue running after the restore.
+Samba Active Directory requires a network bridge and an additional, free IP
+address in the green zone for the local running container.
 
-If the bridge does not exist anymore, Samba Active Directory is stopped.
+If both the bridge exists and the IP address suits the current network
+configuration, the container will continue running after the restore.
+
+Otherwise Samba Active Directory is forcibly stopped.
 To enable it again:
 
-- create the bridge, eg. ``br0``
+- create the bridge, e.g. ``br0``
+- find an unused IP address in your green network, e.g. ``192.168.1.11``
 - reconfigure the container from command line: ::
 
     config setprop nsdc bridge br0 status enabled
-    signal-event nethserver-dc-save
+    signal-event nethserver-dc-change-ip 192.168.1.11
 
 More info about :ref:`ad-local-accounts-provider-section`.
 

--- a/administrator-manual/en/disaster_recovery.rst
+++ b/administrator-manual/en/disaster_recovery.rst
@@ -201,7 +201,7 @@ configuration, the container will continue running after the restore.
 Otherwise Samba Active Directory is forcibly stopped.
 To enable it again:
 
-- create the bridge, e.g. ``br0``
+- from the :guilabel:`Network` page, create the bridge, e.g. ``br0``
 - find an unused IP address in your green network, e.g. ``192.168.1.11``
 - reconfigure the container from command line: ::
 

--- a/administrator-manual/en/disaster_recovery.rst
+++ b/administrator-manual/en/disaster_recovery.rst
@@ -192,6 +192,11 @@ See also :ref:`dhcp-section` for more general information.
 Samba Active Directory
 ^^^^^^^^^^^^^^^^^^^^^^
 
+.. warning::
+
+  Restoring a local Samba Active Directory without the :guilabel:`Restore
+  network configuration` is highly discouraged. Read carefully this section.
+
 Samba Active Directory requires a network bridge and an additional, free IP
 address in the green zone for the local running container.
 

--- a/administrator-manual/en/disaster_recovery.rst
+++ b/administrator-manual/en/disaster_recovery.rst
@@ -213,6 +213,10 @@ To enable it again:
     config setprop nsdc bridge br0 status enabled
     signal-event nethserver-dc-change-ip 192.168.1.11
 
+- fix the DC sysvol ACLs: ::
+
+    /etc/e-smith/events/actions/nethserver-dc-sysvolreset
+
 More info about :ref:`ad-local-accounts-provider-section`.
 
 Firewall

--- a/administrator-manual/en/disaster_recovery.rst
+++ b/administrator-manual/en/disaster_recovery.rst
@@ -195,7 +195,7 @@ Samba Active Directory
 .. warning::
 
   Restoring a local Samba Active Directory without the :guilabel:`Restore
-  network configuration` is highly discouraged. Read carefully this section.
+  network configuration` option enabled is highly discouraged. Read carefully this section.
 
 Samba Active Directory requires a network bridge and an additional, free IP
 address in the green zone for the local running container.


### PR DESCRIPTION
This is a draft procedure to restart the nsdc service after a "skip network" restore. I need to test it.

https://github.com/NethServer/dev/issues/6099