### PR TITLE
backup: add note for rsync

### DIFF
--- a/administrator-manual/en/backup_customization.rst
+++ b/administrator-manual/en/backup_customization.rst
@@ -147,6 +147,8 @@ During data transfer, SFTP assures encryption and data is compressed to minimize
    Please note that |product| doesn't support links on Samba shares due to security implications.
    Also symlinks are not supported on WebDAV.
 
+   The destination must be accessed with ``root`` user.
+
 Command line execution
 ----------------------
 


### PR DESCRIPTION
The rsync script does not support `--fake-super` option.