### PR TITLE
docs. update blacklist chapter

### DIFF
--- a/administrator-manual/en/blacklist.rst
+++ b/administrator-manual/en/blacklist.rst
@@ -29,6 +29,8 @@ Administrators can choose a public repository or subscribe to a commercial servi
 
 A popular free IP blacklist is `Firehol <https://github.com/firehol/blocklist-ipsets>`_. Experienced administrators can also `setup their own IP blacklist server <https://docs.nethserver.org/projects/nethserver-devel/en/latest/nethserver-blacklist.html#setup-a-blacklist-server>`_.
 
+.. warning:: If :ref:`proxy-section` is enabled, in any mode, :guilabel:`DNS blacklist` will not work for proxied hosts.
+
 Whitelist
 ---------
 


### PR DESCRIPTION
DNS blacklist does not work for host proxied with web proxy. We cannot specify on `squid.conf` a custom port (the `pihole` one) to `dns_nameservers` prop.

We can eventually add on `/etc/dnsmasq.conf` the attribute `addn-hosts` with the dns blacklist to correctly block domains. For example:
```
...
addn-hosts=/path/to/dns/blacklists.dns
...
```

But this method and some quirks (redirection on nethserver launcher i.e.), and it's not a valid alternative.

We simply decided to document that this feature is currently unavailable

Nethserver/dev#6212