### PR TITLE
Disable smartquotes in nsent

### DIFF
--- a/administrator-manual/en/conf.py
+++ b/administrator-manual/en/conf.py
@@ -76,6 +76,7 @@ highlight_language = 'none'
 htmlhelp_basename = 'NethServer_enterprisedoc'
 
 if tags.has('nsent'):
+    smartquotes = False
     templates_path = ['nsent/_templates']
     project = u'NethServer Enterprise'
     html_title = "%s %s" % (project, release)


### PR DESCRIPTION
The Sphinx theme uses angular quotes (e.g. «Benvenuto») and are not good in Italian.


See also https://github.com/nethesis/nethvoice-docs/pull/67