### PR TITLE
Fix Email page for Cockpit Server Manager

### DIFF
--- a/administrator-manual/en/base_system2.rst
+++ b/administrator-manual/en/base_system2.rst
@@ -125,6 +125,8 @@ Settings
 
 The :index:`settings` page allows the configuration of some options which could impact multiple system applications.
 
+.. _smart-host:
+
 Smart host
 ^^^^^^^^^^
 

--- a/administrator-manual/en/index.rst
+++ b/administrator-manual/en/index.rst
@@ -71,6 +71,7 @@ Administrator Manual
 
    web_server
    firewall2
+   mail
 
 .. toctree::
    :maxdepth: 1
@@ -80,7 +81,6 @@ Administrator Manual
    disaster_recovery
    backup_customization
    backup_legacy
-   mail
    webmail
    webtop5
    pop3_connector

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -87,10 +87,13 @@ Append a legal notice
     because the alterMIME [#alterMIME]_ project which provides the actual
     implementation is no longer developed and can stop working at any time.
 
-If the optional ``nethserver-mail-disclaimer`` package was installed from the
-:guilabel:`Software center`, |product| can automatically :guilabel:`append a
-legal notice to sent messages`. This text is also known as "disclaimer" and
+If the optional ``nethserver-mail-disclaimer`` package was installed,
+|product| can automatically append a
+legal notice to sent messages. This text is also known as "disclaimer" and
 it can be used to meet some legal requirements.
+
+To configure and enable the *disclaimer attachment*, turn on the option switch
+:guilabel:`Email > Domains [List item] > Edit > Append a legal note to sent messages`.
 
 The disclaimer text can contain Markdown [#Markdown]_ code to format the text.
 

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -87,7 +87,7 @@ Append a legal notice
     because the alterMIME [#alterMIME]_ project which provides the actual
     implementation is no longer developed and can stop working at any time.
 
-If the optional ``nethserver-mail-disclaimer`` package was installed,
+If the optional ``nethserver-mail-disclaimer`` RPM was installed from the terminal,
 |product| can automatically append a
 legal notice to sent messages. This text is also known as "disclaimer" and
 it can be used to meet some legal requirements.
@@ -348,9 +348,9 @@ For more information on Rspamd, please read the :ref:`rspamd-section` page.
       Please make sure the quarantine mailbox has been created only for this specific purpose,
       otherwise the mailbox will be overloaded with unwanted spam.
 
-    Quarantine is provided by an optional module named
+    Quarantine is provided by an optional RPM named
     ``nethserver-mail-quarantine``. Once it has been installed from the
-    :guilabel:`Software center` you must manually set its database properties.
+    terminal you must manually set its database properties.
 
     The properties are under the ``rspamd`` key (configuration database): ::
 

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -42,12 +42,12 @@ Domains
 =======
 
 |product| can handle an unlimited number of mail domains, configurable
-from the :guilabel:`Email > Domains` page.  For each domain there are
+from the :guilabel:`Email > Domains` page. For each domain there are
 two alternatives:
 
 * *Deliver* messages to local mailboxes, according to the Maildir
-  [#MailDirFormat]_ format.
-* *Relay* messages to another mail server.
+  [#MailDirFormat]_ format
+* *Relay* messages to another mail server
 
 .. note:: If a domain is deleted, email will not be deleted;
    any message already received is preserved.
@@ -107,12 +107,12 @@ Disclaimer example: ::
 
   This email and any files transmitted with it are confidential and
   intended solely for the use of the individual or entity to whom they
-  are addressed.  If you have received this email in error please
-  notify the system manager.  This message contains confidential
+  are addressed. If you have received this email in error please
+  notify the system manager. This message contains confidential
   information and is intended only for the individual named.
 
 The **signature** should be inserted inside the message text only by the
-mail client (MUA): Outlook, Thunderbird, etc.  Usually it is a
+mail client (MUA): Outlook, Thunderbird, etc. Usually it is a
 user-defined text containing information such as sender addresses and
 phone numbers.
 
@@ -170,11 +170,11 @@ carrying forbidden file formats. The server can check the following
 attachment classes:
 
 * :index:`executables` (eg. exe, msi)
-* :index:`archives`  (eg. zip, tar.gz, docx)
+* :index:`archives` (eg. zip, tar.gz, docx)
 * custom file format list
 
 The system recognizes file types by looking at their contents,
-regardless of the file attachment name.  Therefore it is possible that
+regardless of the file attachment name. Therefore it is possible that
 MS Word file (docx) and OpenOffice (odt) are blocked because they
 actually are also zip archives.
 
@@ -363,7 +363,7 @@ For more information on Rspamd, please read the :ref:`rspamd-section` page.
 
     * ``QuarantineAccount``: The user or the shared mailbox where to send all spam messages (spam
       check is automatically disabled on this account). You must create it
-      manually. You could send it to an external mailbox  but then make sure to
+      manually. You could send it to an external mailbox but then make sure to
       disable the spam check on the remote server
 
     * ``QuarantineStatus``: Enable the quarantine, spam are no more rejected:
@@ -397,7 +397,7 @@ Users mailboxes
 ---------------
 
 The :guilabel:`Edit` button allows disabling the :guilabel:`Access to
-email services` (IMAP, POP3, SMTP/AUTH) for a specific user.  Messages delivered
+email services` (IMAP, POP3, SMTP/AUTH) for a specific user. Messages delivered
 to that user's mailbox can be forwarded to multiple external email addresses.
 
 .. warning::
@@ -433,7 +433,7 @@ Public mailboxes
 .. index::
     pair: public; mailbox
 
-Public mailboxes can be shared among groups of users.  The :guilabel:`Email >
+Public mailboxes can be shared among groups of users. The :guilabel:`Email >
 Mailboxes > Public mailboxes` section allows creating a new public mailbox
 and defining one or more owning groups. Public mailboxes can also be created by
 any IMAP client supporting IMAP ACL protocol extension (RFC 4314).
@@ -461,9 +461,9 @@ mail contents over the network.
    triple: email; custom; quota
 
 From the same page, the :guilabel:`Quota limit` for each mailbox can be
-limited to a default quota.  If the general mailbox quota is enabled, the
+limited to a default quota. If the general mailbox quota is enabled, the
 :guilabel:`Email > Mailboxes` list summarizes the quota usage for
-each user.  This summary is updated when a user logs in or a message is
+each user. This summary is updated when a user logs in or a message is
 delivered. The quota can be customized for a specific user in :guilabel:`Email
 > Mailboxes [users item] > Edit > Custom mailbox quota`.
 
@@ -474,7 +474,7 @@ delivered. The quota can be customized for a specific user in :guilabel:`Email
 Messages marked as **spam** (see :ref:`email_filter`) can be automatically
 moved into the :dfn:`Junk` folder by enabling the option
 :guilabel:`Move spam to "Junk" folder`. Spam messages are expunged
-automatically after the :guilabel:`Keep spam for` period has elapsed.  The
+automatically after the :guilabel:`Keep spam for` period has elapsed. The
 spam retention period can be customized for a specific user in
 :guilabel:`Email > Mailboxes [users item] > Edit > Custom spam retention`.
 
@@ -482,7 +482,7 @@ spam retention period can be customized for a specific user in
    pair: email; master user
 
 The ``root`` user can impersonate another user, gaining full rights
-to any mailbox contents and folder permissions.  The
+to any mailbox contents and folder permissions. The
 :guilabel:`Root can log in as another user` option controls this
 empowerment, known also as *master user* in Dovecot [#Dovecot]_.
 
@@ -556,10 +556,10 @@ addresses, from the :guilabel:`Email > Addresses` page. Each
 :dfn:`mail address` is associated with one or more destinations. A
 :dfn:`destination` can be of the following types:
 
-* user mailbox,
-* groups mailbox,
-* public mailbox,
-* external email address.
+* user mailbox
+* groups mailbox
+* public mailbox
+* external email address
 
 A mail address can be bound to any mail domain or be specific to one mail domain.
 For example:
@@ -579,7 +579,7 @@ Sometimes a company forbids communications from outside the organization
 using personal email addresses. The :guilabel:`Internal` check box
 (formerly :guilabel:`Local network only`) and the :guilabel:`Make internal`
 and :guilabel:`Make public` action buttons block the possibility of an address
-to receive messages from the outside.  Still an *internal* address can be used to
+to receive messages from the outside. Still an *internal* address can be used to
 exchange messages with other accounts of the system.
 
 .. _email-connectors:
@@ -594,7 +594,7 @@ The :guilabel:`Email > Connectors` page is described in :ref:`pop3_connector-sec
 Synchronization
 ===============
 
-The :guilabel:`Email > Synchronization` page  is based on an IMAP transfer tool called Imapsync.
+The :guilabel:`Email > Synchronization` page is based on an IMAP transfer tool called Imapsync.
 The purpose is to migrate email messages from a remote IMAP account to a
 local one.
 
@@ -630,7 +630,7 @@ should be empty or contain just a few messages.
 
 The :guilabel:`Email > Queue [Charts] > Show charts` link shows a real-time
 chart of the mail queue status in the last minutes, updated as the page is left opened.
-The chart shows the number of message in the queue and the total queue size in kilo bytes.
+The chart shows the number of message in the queue and the total queue size in kilobytes.
 
 While messages are in the queue, the administrator can request an
 immediate message relay attempt, by pressing the button
@@ -705,14 +705,14 @@ Custom HELO
 -----------
 
 The first step of an SMTP session is the exchange of :dfn:`HELO`
-command (or :dfn:`EHLO`).  This command takes a valid server name as
+command (or :dfn:`EHLO`). This command takes a valid server name as
 required parameter (RFC 1123).
 
 |product| and other mail servers try to reduce spam by not accepting
 HELO domains that are not registered on a public DNS.
 
 When talking to another mail server, |product| uses its full host name
-(FQDN) as the value for the HELO command.  If the FQDN is not
+(FQDN) as the value for the HELO command. If the FQDN is not
 registered in the public DNS, the HELO can be changed in the
 :guilabel:`Custom HELO` text field.
 
@@ -750,11 +750,11 @@ relying on the standard SMTP relay rules.
 
 The :guilabel:`System > Settings > Smart host` section, configures the outgoing
 messages to be directed through a special SMTP server, technically
-named :dfn:`smarthost`.  A smarthost accepts to relay messages under
+named :dfn:`smarthost`. A smarthost accepts to relay messages under
 some restrictions. It could check:
 
-* the client IP address,
-* the client SMTP AUTH credentials.
+* the client IP address
+* the client SMTP AUTH credentials
 
 Refer also to :ref:`smart-host` for more information.
 
@@ -780,13 +780,13 @@ waiting for final delivery or relay. When |product| relays a message
 to a remote server, errors may occur. For instance,
 
 * the network connection fails, or
-* the other server is down or is overloaded.
+* the other server is down or is overloaded
 
 Those and other errors are *temporary*: in such cases, |product|
 attempts to reconnect the remote host at regular intervals until a
 limit is reached. The :guilabel:`Message queue lifetime` (formerly
 :guilabel:`Queue message lifetime`) slider
-changes this limit.  By default it is set to *4 days*.
+changes this limit. By default it is set to *4 days*.
 
 .. index::
    pair: email; always send a copy
@@ -800,8 +800,8 @@ is different from the same check box under :guilabel:`Email > Domains` as
 it does not differentiate between mail domains and catches also any
 outgoing message.
 
-.. warning:: On some countries, enabling the *Always send a copy
-             (Bcc)* can be against privacy laws.
+.. warning:: On some countries, enabling the *Forward a copy of
+             all messages* can be against privacy laws.
 
 
 .. _email_log:
@@ -816,11 +816,11 @@ Every mail server operation is saved in the following log files:
   plus the IMAP actions, if enabled in :ref:`email_mailboxes_settings`
 
 A transaction recorded in the :file:`maillog` file usually involves
-different components of the mail server.  Each line contains
+different components of the mail server. Each line contains
 respectively
 
-* the timestamp,
-* the host name,
+* the timestamp
+* the host name
 * the component name, and the process-id of the component instance
 * a text message detailing the operation
 

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -171,9 +171,10 @@ to that user's mailbox can be forwarded to multiple external email addresses.
 Groups mailboxes
 ----------------
 
-The Groups mailboxes are initially disabled. If enabled, addresses like
-*<groupname>@<domain>* become valid email addresses. A specific group address
+The *automatic aliases for groups mailboxes* are initially disabled. If enabled,
+addresses like *<groupname>@<domain>* become valid email addresses. A specific group address
 can be disabled and enabled again in a later stage, once Groups mailboxes are enabled.
+to disable the automatic aliases globally, refer to :ref:`email_mailboxes_settings`.
 
 A group mailbox has no disk space for it. When a message is sent to a group mailbox,
 a copy of it is delivered to the group members, according to their delivery and forward
@@ -257,6 +258,23 @@ use the following credentials:
 
 * user name: ``john*root``
 * password: ``secr3t``
+
+Additional options:
+
+* If *Groups mailboxes* were enabled in guilabel:`Email > Mailboxes > Groups`,
+  unselect the :guilabel:`Automatic alias for groups` check box to disable them again.
+
+* It is possible to record the IMAP actions by enabling :guilabel:`Log IMAP actions`.
+  See also :ref:`email_log`.
+
+* An option useful for MS Outlook clients is :guilabel:`Move deleted email to trash (Outlook)`.
+  Outlook clients mark messages as deleted but does not automatically move them to the Trash folder.
+  Once enabled, this option does it automatically.
+
+* :guilabel:`Max user connections per IP` changes the limit of connections for a user coming from
+  the same IP address. This limit could be increased if messages like
+  *Maximum number of connections* appear in the log files (see :ref:`email_log`).
+
 
 *Shared seen* configuration
 ---------------------------
@@ -782,7 +800,8 @@ Log
 Every mail server operation is saved in the following log files:
 
 * :file:`/var/log/maillog` registers all mail transactions
-* :file:`/var/log/imap` contains users login and logout operations
+* :file:`/var/log/imap` contains users login and logout operations,
+  plus the IMAP actions, if enabled in :ref:`email_mailboxes_settings`
 
 A transaction recorded in the :file:`maillog` file usually involves
 different components of the mail server.  Each line contains

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -219,7 +219,7 @@ adjusted under :guilabel:`Email > Filter > Anti spam`.
    that a spammer is in hurry and is likely to give up, whilst a
    SMTP-compliant MTA will attempt to deliver the deferred message again.
 
-2. If the spam score is above :guilabel:`Spam threshold` the message is **marked
+2. If the spam score is above :guilabel:`Spam flag threshold` the message is **marked
    as spam** by adding the special header ``X-Spam: Yes`` for specific
    treatments, then it is delivered like other messages. As an alternative, the
    :guilabel:`Add a prefix to spam messages subject` option makes the spam flag

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -140,23 +140,26 @@ instructions of your DNS provider to run the following steps:
 
 2. Copy and paste the given key text in the DNS record data (RDATA) section
 
-.. index:: email address, pseudonym
+.. _email_mailboxes:
 
-.. _email_addresses:
-
-Email addresses
-===============
+Mailboxes
+=========
 
 .. index::
     pair: user; mailbox
 
-Each user has a personal :dfn:`mailbox` and any user name in the form
+Each user has a personal mailbox and any user name in the form
 *<username>@<domain>* is also a valid email address to deliver messages into it.
 
-The list of mailboxes is shown by the :guilabel:`Email addresses > User
-mailboxes` page. The :guilabel:`Edit` button allows disabling the :guilabel:`Access to
+The list of mailboxes is shown by the :guilabel:`Email > Mailboxes` page. There
+are three types of mailboxes: Users, Groups and Public mailboxes.
+
+Users mailboxes
+---------------
+
+The :guilabel:`Edit` button allows disabling the :guilabel:`Access to
 email services` (IMAP, POP3, SMTP/AUTH) for a specific user.  Messages delivered
-to that user's mailbox can be forwarded to an external email address.
+to that user's mailbox can be forwarded to multiple external email addresses.
 
 .. warning::
 
@@ -165,24 +168,55 @@ to that user's mailbox can be forwarded to an external email address.
     mailbox must be erased manually. The file system path prefix is
     :file:`/var/lib/nethserver/vmail/`.
 
+Groups mailboxes
+----------------
+
+The Groups mailboxes are initially disabled. If enabled, addresses like
+*<groupname>@<domain>* become valid email addresses. A specific group address
+can be disabled and enabled again in a later stage, once Groups mailboxes are enabled.
+
+A group mailbox has no disk space for it. When a message is sent to a group mailbox,
+a copy of it is delivered to the group members, according to their delivery and forward
+preferences.
+
+Public mailboxes
+----------------
+
 .. index::
     pair: shared; mailbox
 
-Mailboxes can be shared among groups of users.  The :guilabel:`Email addresses >
-Shared mailboxes` page allows creating a new :dfn:`shared mailbox` and defining
-one or more owning groups. Shared mailboxes can also be created by any IMAP
-client supporting IMAP ACL protocol extension (RFC 4314).
+.. note::
 
-The system enables the creation of an unlimited number of additional email
-addresses, from the :guilabel:`Email addresses > Mail aliases` page. Each
-:dfn:`mail alias` is associated with one or more destinations. A
+   In the old Server Manager the :guilabel:`Shared mailboxes` label was used
+   in place of :guilabel:`Public mailboxes`.
+
+.. index::
+    pair: public; mailbox
+
+Public mailboxes can be shared among groups of users.  The :guilabel:`Email >
+Mailboxes > Public mailboxes` section allows creating a new public mailbox
+and defining one or more owning groups. Public mailboxes can also be created by
+any IMAP client supporting IMAP ACL protocol extension (RFC 4314).
+
+.. index:: email address, pseudonym
+
+.. _email_addresses:
+
+Addresses
+=========
+
+In addition to the Users, Groups and Public mailboxes addresses, described in the
+previous section, the system enables the creation of an unlimited number of email
+addresses, from the :guilabel:`Email > Addresses` page. Each
+:dfn:`mail address` is associated with one or more destinations. A
 :dfn:`destination` can be of the following types:
 
 * user mailbox,
-* shared mailbox,
+* groups mailbox,
+* public mailbox,
 * external email address.
 
-A mail alias can be bound to any mail domain or be specific to one mail domain.
+A mail address can be bound to any mail domain or be specific to one mail domain.
 For example:
 
 * First domain: mydomain.net
@@ -197,20 +231,12 @@ For example:
    triple: email; private; internal
 
 Sometimes a company forbids communications from outside the organization
-using personal email addresses. The :guilabel:`Local network only` (or visibility :guilabel:`Internal`)
-option blocks the possibility of an address to receive email from the
-outside.  Still the "local network only" address can be used to
+using personal email addresses. The :guilabel:`Internal` check box
+(formerly :guilabel:`Local network only`) and the :guilabel:`Make internal`
+and :guilabel:`Make public` buttons block the possibility of an address
+to receive messages from the outside.  Still an *internal* address can be used to
 exchange messages with other accounts of the system.
 
-Differences in the new Server Manager
--------------------------------------
-
-Please note that "Shared mailboxes" has been renamed to "Public mailboxes".
-Also, if enabled from the :guilabel:`Mailboxes` page, the mail server can automatically
-create aliases of existing groups. A mail sent to the group alias will be
-copied and delivered to each member of the group.
-
-.. _email_mailboxes:
 
 Mailbox configuration
 =====================

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -198,6 +198,87 @@ Mailboxes > Public mailboxes` section allows creating a new public mailbox
 and defining one or more owning groups. Public mailboxes can also be created by
 any IMAP client supporting IMAP ACL protocol extension (RFC 4314).
 
+.. _email_mailboxes_settings:
+
+General settings
+----------------
+
+The :guilabel:`Email > Mailboxes (General settings) > Configure` page controls what protocols are
+available to access the user's mailbox:
+
+* IMAP [#IMAP]_ (recommended)
+* POP3 [#POP3]_ (obsolete)
+
+For security reasons, all protocols require STARTTLS encryption by
+default.  The :guilabel:`Allow unencrypted connections` check box,
+disables this important requirement, and allows passing clear-text passwords and
+mail contents over the network.
+
+.. warning:: Do not allow unencrypted connections on production
+             environments!
+
+.. index::
+   triple: email; custom; quota
+
+From the same page, the :guilabel:`Quota limit` for each mailbox can be
+limited to a default quota.  If the general mailbox quota is enabled, the
+:guilabel:`Email > Mailboxes` list summarizes the quota usage for
+each user.  This summary is updated when a user logs in or a message is
+delivered. The quota can be customized for a specific user in :guilabel:`Email
+> Mailboxes [users item] > Edit > Custom mailbox quota`.
+
+.. index::
+   pair: email; spam retention
+   triple: email; custom; spam retention
+
+Messages marked as **spam** (see :ref:`email_filter`) can be automatically
+moved into the :dfn:`Junk` folder by enabling the option
+:guilabel:`Move spam to "Junk" folder`. Spam messages are expunged
+automatically after the :guilabel:`Keep spam for` period has elapsed.  The
+spam retention period can be customized for a specific user in
+:guilabel:`Email > Mailboxes [users item] > Edit > Custom spam retention`.
+
+.. index::
+   pair: email; master user
+
+The ``root`` user can impersonate another user, gaining full rights
+to any mailbox contents and folder permissions.  The
+:guilabel:`Root can log in as another user` option controls this
+empowerment, known also as *master user* in Dovecot [#Dovecot]_.
+
+When :guilabel:`Root can log in as another user` is enabled, the following
+credentials are accepted by the IMAP server:
+
+* user name with ``*root`` suffix appended
+* root's password
+
+For instance, to access as ``john`` with root password ``secr3t``,
+use the following credentials:
+
+* user name: ``john*root``
+* password: ``secr3t``
+
+*Shared seen* configuration
+---------------------------
+
+Users could share their mailbox (or some parts of it, folders) with selected accounts on the system. 
+Everyone who is given access to a shared mailbox can read or delete messages according to permissions
+granted by the mailbox owner.
+
+An IMAP flag named ``/Seen`` is used to mark if a message has been read or not. In a shared mailbox,
+each user has their copy of the messages they have read, but sometimes a team sharing a mailbox
+could prefer to know if a mail has already been read by someone else.
+To enable sharing of the ``/Seen`` flag for all shared mailboxes use the following commands: ::
+
+    config setprop dovecot SharedSeen enabled
+    signal-event nethserver-mail-server-save
+
+Please note that changing the ``SharedSeen`` status resets the ``/Seen`` flag for all users on all mailboxes.
+
+Public folders are created by the administrator and are usually visible to all users (or large groups).
+The ``/Seen`` flag is kept for each user and it cannot be shared.
+
+
 .. index:: email address, pseudonym
 
 .. _email_addresses:
@@ -236,83 +317,6 @@ using personal email addresses. The :guilabel:`Internal` check box
 and :guilabel:`Make public` buttons block the possibility of an address
 to receive messages from the outside.  Still an *internal* address can be used to
 exchange messages with other accounts of the system.
-
-
-Mailbox configuration
-=====================
-
-The :guilabel:`Email > Mailboxes` page controls what protocols are
-available to access a user mailbox:
-
-* IMAP [#IMAP]_ (recommended)
-* POP3 [#POP3]_ (obsolete)
-
-For security reasons, all protocols require STARTTLS encryption by
-default.  The :guilabel:`Allow unencrypted connections`, disables this
-important requirement, and allows passing clear-text passwords and
-mail contents on the network.
-
-.. warning:: Do not allow unencrypted connections on production
-             environments!
-
-.. index::
-   triple: email; custom; quota
-
-From the same page, the :guilabel:`disk space` of each mailbox can be
-limited to a default :dfn:`quota`.  If the mailbox quota is enabled, the
-:guilabel:`Dashboard > Mail quota` page summarizes the quota usage for
-each user.  This summary is updated when a user logs in or a message is
-delivered. The quota can be customized for a specific user in :guilabel:`Email
-addresses > User mailboxes > Edit > Custom mailbox quota`.
-
-.. index::
-   pair: email; spam retention
-   triple: email; custom; spam retention
-
-Messages marked as **spam** (see :ref:`email_filter`) can be automatically
-moved into the :dfn:`Junk` folder by enabling the option
-:guilabel:`Move to "Junk" folder`. Spam messages are expunged
-automatically after the :guilabel:`Hold for` period has elapsed.  The
-spam retention period can be customized for a specific user in
-:guilabel:`Email addresses > User mailboxes > Edit > Customize spam message
-retention`.
-
-.. index::
-   pair: email; master user
-
-The ``root`` user can impersonate another user, gaining full rights
-to any mailbox contents and folder permissions.  The
-:guilabel:`Root can log in as another user` option controls this
-empowerment, known also as *master user* in Dovecot [#Dovecot]_.
-
-When :guilabel:`Root can log in as another user` is enabled, the following
-credentials are accepted by the IMAP server:
-
-* user name with ``*root`` suffix appended
-* root's password
-
-For instance, to access as ``john`` with root password ``secr3t``,
-use the following credentials:
-
-* user name: ``john*root``
-* password: ``secr3t``
-
-Users could share their mailbox (or some parts of it, folders) with selected accounts on the system. 
-Everyone who is given access to a shared mailbox can read or delete messages according to permissions
-granted by the mailbox owner.
-
-An IMAP flag named ``/Seen`` is used to mark if a message has been read or not. In a shared mailbox,
-each user has their copy of the messages they have read, but sometimes a team sharing a mailbox
-could prefer to know if a mail has already been read by someone else.
-To enable sharing of the ``/Seen`` flag for all shared mailboxes use the following commands: ::
-
-    config setprop dovecot SharedSeen enabled
-    signal-event nethserver-mail-server-save
-
-Please note that changing the ``SharedSeen`` status resets the ``/Seen`` flag for all users on all mailboxes.
-
-Public folders are created by the administrator and are usually visible to all users (or large groups).
-The ``/Seen`` flag is kept for each user and it cannot be shared.
 
 
 .. _email_messages:

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -127,8 +127,8 @@ DomainKeys Identified Mail (DKIM) [#DKIM]_ provides a way to validate the
 sending MTA, which adds a cryptographic signature to the outbound message MIME
 headers.
 
-To enable the DKIM signature for a mail domain, enable :guilabel:`Email >
-Domains > Sign outbound messages with DomainKeys Identified Mail (DKIM)`.
+To enable the DKIM signature for a mail domain, enable the :guilabel:`Signature` switch
+under :guilabel:`Email > Domains > [list item] > Configure DKIM`.
 
 The DKIM signature headers are added only to messages sent through TCP ports 587
 (submission) and 465 (smtps).

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -60,10 +60,11 @@ two alternatives:
 |product| allows storing an :dfn:`hidden copy` of all messages
 directed to a particular domain: they will be delivered to the final
 recipient *and also* to a custom email address. The hidden copy is
-enabled by the :guilabel:`Always send a copy (Bcc)` check box.
+enabled by the :guilabel:`Copy inbound messages` switch
+(formerly :guilabel:`Always send a copy (Bcc)` check box).
 
-.. warning:: On some countries, enabling the *Always send a copy
-             (Bcc)* can be against privacy laws.
+.. warning:: On some countries, enabling the *Copy inbound messages*
+             switch can be against privacy laws.
 
 If the final recipient cannot be established (i.e. the recipient address does
 not exist), the message is normally rejected. Sometimes (i.e. when a mail domain

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -262,7 +262,7 @@ It is important to understand how the Bayesian tests really work:
 
 * A message can only be flagged one time. If the same message is flagged multiple times, it will not affect anything as the dynamic tests have already been trained by that message.
 
-* The Bayesian tests **are not active until it has received enough information. This includes a minimum of 200 spams AND 200 hams (false positives).**
+* The Bayesian filter **is not active until it has received enough information. This includes a minimum of 200 spams AND 200 hams (false positives).**
 
   As the system receives that information, the progress of bayesian filter training
   can be monitored from the :guilabel:`Email > Filter [Statistics] > Bayes training` progress bar.

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -174,7 +174,7 @@ Groups mailboxes
 The *automatic aliases for groups mailboxes* are initially disabled. If enabled,
 addresses like *<groupname>@<domain>* become valid email addresses. A specific group address
 can be disabled and enabled again in a later stage, once Groups mailboxes are enabled.
-to disable the automatic aliases globally, refer to :ref:`email_mailboxes_settings`.
+To disable the automatic aliases globally, refer to :ref:`email_mailboxes_settings`.
 
 A group mailbox has no disk space for it. When a message is sent to a group mailbox,
 a copy of it is delivered to the group members, according to their delivery and forward
@@ -204,7 +204,7 @@ any IMAP client supporting IMAP ACL protocol extension (RFC 4314).
 General settings
 ----------------
 
-The :guilabel:`Email > Mailboxes (General settings) > Configure` page controls what protocols are
+The :guilabel:`Email > Mailboxes [General settings] > Configure` page controls what protocols are
 available to access the user's mailbox:
 
 * IMAP [#IMAP]_ (recommended)
@@ -261,7 +261,7 @@ use the following credentials:
 
 Additional options:
 
-* If *Groups mailboxes* were enabled in guilabel:`Email > Mailboxes > Groups`,
+* If *Groups mailboxes* were enabled in :guilabel:`Email > Mailboxes > Groups`,
   unselect the :guilabel:`Automatic alias for groups` check box to disable them again.
 
 * It is possible to record the IMAP actions by enabling :guilabel:`Log IMAP actions`.
@@ -318,11 +318,11 @@ addresses, from the :guilabel:`Email > Addresses` page. Each
 A mail address can be bound to any mail domain or be specific to one mail domain.
 For example:
 
-* First domain: mydomain.net
-* Second domain: example.com
-* Email address *info* valid for both domains: info@mydomain.net,
-  info@example.com
-* Email address *goofy* valid only for one domain: goofy@example.com
+* First domain: ``mydomain.net``
+* Second domain: ``example.com``
+* Email address *info* bound to any domain: ``info@mydomain.net``,
+  ``info@example.com``
+* Email address *goofy* specific to one domain: ``goofy@example.com``
 
 .. index::
    pair: email; local network only
@@ -332,7 +332,7 @@ For example:
 Sometimes a company forbids communications from outside the organization
 using personal email addresses. The :guilabel:`Internal` check box
 (formerly :guilabel:`Local network only`) and the :guilabel:`Make internal`
-and :guilabel:`Make public` buttons block the possibility of an address
+and :guilabel:`Make public` action buttons block the possibility of an address
 to receive messages from the outside.  Still an *internal* address can be used to
 exchange messages with other accounts of the system.
 

--- a/administrator-manual/en/mail.rst
+++ b/administrator-manual/en/mail.rst
@@ -155,15 +155,15 @@ Filter
 All transiting email messages are subjected to a list of checks that
 can be selectively enabled in :guilabel:`Email > Filter` page:
 
-* Block of attachments
+* Attachments
 * Antivirus
 * Antispam
 
 .. index::
    pair: email; attachment
 
-Block of attachments
---------------------
+Attachments
+-----------
 
 The system can inspect mail attachments, denying access to messages
 carrying forbidden file formats. The server can check the following
@@ -238,9 +238,11 @@ evolve and quickly adapt analyzing messages marked as **spam** or
 
 The statistical filters can then be trained with any IMAP client by
 simply moving a message in and out of the :dfn:`Junk folder`. As a
-prerequisite, the Junk folder must be enabled from
-:guilabel:`Email > Mailboxes` page by checking :guilabel:`Move to
-"Junk" folder"` option.
+prerequisite, the Junk folder must be enabled from the
+:guilabel:`Email > Mailboxes [General settings] > Configure
+[Advanced options] > Move spam to "Junk" folder` check box
+(formerly :guilabel:`Email > Mailboxes > Move to
+"Junk" folder"` check box).
 
 * By *putting a message into the Junk folder*, the filters learn
   it is spam and will assign an higher score to similar messages.
@@ -262,6 +264,9 @@ It is important to understand how the Bayesian tests really work:
 
 * The Bayesian tests **are not active until it has received enough information. This includes a minimum of 200 spams AND 200 hams (false positives).**
 
+  As the system receives that information, the progress of bayesian filter training
+  can be monitored from the :guilabel:`Email > Filter [Statistics] > Bayes training` progress bar.
+
 .. note:: It is a good habit to frequently check the Junk folder
           in order not to lose email wrongly recognized as spam.
 
@@ -269,13 +274,16 @@ It is important to understand how the Bayesian tests really work:
    pair: email; whitelist
    pair: email; blacklist
 
+Rules for white and black lists
+-------------------------------
+
 If the system fails to recognize spam properly even after training,
 the *whitelists* and *blacklists* can help. Those are lists of email
 addresses or domains respectively always allowed and always blocked to
 send or receive messages.
 
-The section :guilabel:`Rules by mail address` allows creating
-three types of rules:
+The section :guilabel:`Email > Filter [Rules] > Details` (formerly
+:guilabel:`Rules by mail address`) allows creating three types of rules:
 
 * :guilabel:`Allow From`: any message from specified sender is
   accepted


### PR DESCRIPTION
The Email page still refers to the old Server Manager UI. We added many features and changed some UI labels. This PR is to align the documentation with the new UI.

https://github.com/NethServer/dev/issues/6247