### PR TITLE
Fix disable tftp in dhcp.rst

### DIFF
--- a/administrator-manual/en/dhcp.rst
+++ b/administrator-manual/en/dhcp.rst
@@ -105,7 +105,7 @@ put it in :file:`/var/lib/tftpboot` directory.
 .. note:: To disable TFTP type the following commands in a root's
           console: ::
 	    
-	     config setprop dhcp tftp-status disabled
+	     config setprop dnsmasq tftp-status disabled
 	     signal-event nethserver-dnsmasq-save
 
 For instance, we now configure a client to boot CentOS from the


### PR DESCRIPTION
Fix the disable tftp part, it's dnsmasq instead of dhcp.

See https://community.nethserver.org/t/cant-open-directory-etc-e-smith-events-nethserver-tftp-save/19010

Thanks to fausp