### PR TITLE
Updated Sphinx_rtd_theme at the latest compatible version

### DIFF
--- a/administrator-manual/en/nscom/requirements.txt
+++ b/administrator-manual/en/nscom/requirements.txt
@@ -1,2 +1,2 @@
 Sphinx===4.2.0
-sphinx_rtd_theme===0.5.1
+sphinx_rtd_theme===1.0.0

--- a/administrator-manual/en/nsent/requirements.txt
+++ b/administrator-manual/en/nsent/requirements.txt
@@ -1,2 +1,2 @@
 Sphinx===4.2.0
-sphinx_rtd_theme===0.5.1
+sphinx_rtd_theme===1.0.0


### PR DESCRIPTION
To avoid problems related to the UI the version of ```sphinx_rtd_theme``` goes from 0.5 to 1.0