### PR TITLE
Update base_system.rst and web_proxy.rst

### DIFF
--- a/administrator-manual/en/base_system.rst
+++ b/administrator-manual/en/base_system.rst
@@ -308,7 +308,7 @@ Let's Encrypt certificate can be disabled following these steps:
 
    ::
 
-     rm -rf /etc/letsencrypt/*
+     rm -rf /etc/letsencrypt/{accounts,archive,csr,keys,live,renewal}
      config setprop pki LetsEncryptDomains ''
 
 Shutdown

--- a/administrator-manual/en/web_proxy.rst
+++ b/administrator-manual/en/web_proxy.rst
@@ -190,7 +190,7 @@ Since all reports are kept forever, the size of the directory can greatly grow d
 To cleanup all reports older than 1 year, execute the following:
 ::
 
-  find /var/lightsquid/  -maxdepth 1 -mindepth 1 -type d -name '????????' -mtime +360 -delete
+  find /var/lightsquid/  -maxdepth 1 -mindepth 1 -type d -name '????????' -mtime +360 -exec rm -rf {} \;
 
 Cache
 =====


### PR DESCRIPTION
We need to change the `rm` command into the `Disable Let's Encrypt` section. If we remove all the content of the path `/etc/letsencrypt/` we loose the `/etc/letsencrypt/renewal-hooks/deploy/10nethserver` script, too. This deletion make the system unable to put in production a new LE certificate.
We also need to change the `find` command used to delete the older `lightsquid` reports.